### PR TITLE
[FIX] broken links

### DIFF
--- a/src/about.md
+++ b/src/about.md
@@ -1,5 +1,7 @@
 # What is this?
 
+[rustc]: https://github.com/rust-lang/rust
+
 Ever wanted to understand how [rustc] works? **This club is for you!** Inspired by the very cool [Code Reading Club](https://code-reading.org/), the idea is to get together every few weeks and just spend some time reading the code in [rustc] or other related projects.
 
 
@@ -14,4 +16,3 @@ We'll be following a "semi-structured" reading process:
 * Dig into how a few of those functions are actually implemented.
 
 The meetings will *not* be recorded, but they will be open to anyone. ≥The first meeting of the Rustc Reading Club will be **November 4th, 2021 at 12:00pm US Eastern time**. Hope to see you there!
-

--- a/src/resources.md
+++ b/src/resources.md
@@ -1,5 +1,7 @@
 # Links and Resources
 
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/
+
 - The [rustc dev guide]
 - [Code coloring tool](https://annotate.code-reading.org/#/) that we use during meetings.
 - [Rustc Code Reading Club Calendar](https://calendar.google.com/calendar/u/0?cid=dWp0NHRyNWVnZnNtZWNvMGU1cGkxbjk0ZDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)


### PR DESCRIPTION
### Description

- unlinked references to "[rustc]" can be found in the first paragraph of the "about" page
- unlinked reference to "[rustc dev guide]" can be found in the "links & resources" page

### Acceptance Criteria

- [x] fix broken links in book